### PR TITLE
Feature/update contacts

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -67,7 +67,7 @@ class ContactsController < ApplicationController
   private
   
   def contact_params
-    params.require(:contact).permit(:name, :jobtitle, :organization, :email, :phone, :contact_type, :incident_id, :incident_role, :user_id, :point_of_contact, :point_of_contact_title )
+    params.require(:contact).permit(:name, :jobtitle, :organization, :email, :phone, :contact_type, :incident_id, :incident_role, :incident_title, :incident_parent, :user_id, :point_of_contact, :point_of_contact_title )
   end
 
 end

--- a/db/migrate/20210727175147_increase_id_integer_limit.rb
+++ b/db/migrate/20210727175147_increase_id_integer_limit.rb
@@ -1,0 +1,5 @@
+class IncreaseIdIntegerLimit < ActiveRecord::Migration[6.1]
+  def change
+    change_column :contacts, :incident_role, :integer, limit: 8
+  end
+end

--- a/db/migrate/20210727231207_increase_parent_id_integer_limit.rb
+++ b/db/migrate/20210727231207_increase_parent_id_integer_limit.rb
@@ -1,0 +1,5 @@
+class IncreaseParentIdIntegerLimit < ActiveRecord::Migration[6.1]
+  def change
+    change_column :contacts, :incident_parent, :integer, limit: 8
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_27_175147) do
+ActiveRecord::Schema.define(version: 2021_07_27_231207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "contacts", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.integer "incident_parent"
+    t.bigint "incident_parent"
     t.bigint "incident_role"
     t.string "contact_type"
     t.string "name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_19_190906) do
+ActiveRecord::Schema.define(version: 2021_07_27_175147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2021_07_19_190906) do
   create_table "contacts", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "incident_parent"
-    t.integer "incident_role"
+    t.bigint "incident_role"
     t.string "contact_type"
     t.string "name"
     t.string "jobtitle"


### PR DESCRIPTION
- Increases the byte limit for id integer values in some columns of the contacts table. In order to create custom nodes on the chart editor, the client was using Date.now() to produce new IDs which were larger than the 4 byte limit. Generated two migrations to increase this limit where necessary.